### PR TITLE
Add topology spread constraints test for RayCluster

### DIFF
--- a/.github/workflows/e2e-tests-reusable-workflow.yaml
+++ b/.github/workflows/e2e-tests-reusable-workflow.yaml
@@ -63,6 +63,14 @@ jobs:
             kubectl apply -f ./ray-operator/config/samples/ray-cluster.sample.yaml
             kubectl wait --timeout=300s --for=condition=ready  pod -l ray.io/cluster=raycluster-sample
 
+        - name: Deploy Kuberay Cluster with Topology Spread Constraints
+          if: inputs.plugin-test
+          run: |
+            echo Deploying Kuberay cluster with Topology Spread Constraints
+
+            kubectl apply -f ./ray-operator/config/samples/ray-cluster.TopoSpreadConst.yaml
+            kubectl wait --timeout=300s --for=condition=ready  pod -l ray.io/cluster=raycluster-sample
+
         - name: Run e2e tests
           run: |
             export KUBERAY_TEST_TIMEOUT_SHORT=1m

--- a/ray-operator/config/samples/ray-cluster.TopoSpreadConst.yaml
+++ b/ray-operator/config/samples/ray-cluster.TopoSpreadConst.yaml
@@ -1,0 +1,86 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: raycluster-topology-test
+  namespace: default
+spec:
+  rayVersion: '2.10.0'
+  enableInTreeAutoscaling: true
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      spec:
+        containers:
+        - name: ray-head
+          image: rayproject/ray:2.10.0
+          resources:
+            limits:
+              cpu: 1
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 2Gi
+          ports:
+          - containerPort: 6379
+            name: gcs-server
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+        topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              ray.io/node-type: head
+  workerGroupSpecs:
+    - groupName: worker-group-1
+      replicas: 3
+      minReplicas: 1
+      maxReplicas: 5
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.10.0
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+          topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                ray.io/node-type: worker
+
+    - groupName: worker-group-2
+      replicas: 3
+      minReplicas: 1
+      maxReplicas: 5
+      rayStartParams: {}
+      template:
+        spec:
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:2.10.0
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 1Gi
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+          topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: DoNotSchedule
+            labelSelector:
+              matchLabels:
+                ray.io/node-type: worker


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
This PR adds a test to verify the functionality of topology spread constraints in a RayCluster setup. The test ensures that worker pods respect the topology spread constraints defined in the cluster's YAML file, particularly focusing on distributing pods across nodes while adhering to maxSkew and avoiding node overloading.
@nemo9cby @liuxsh9 @Superskyyy @Bye-legumes

The modifications include:

A new YAML file with topology spread constraints applied to the worker groups.
An update to the e2e test setup to deploy the cluster with the new topology spread configuration.
Validation logic to ensure pods are scheduled according to the specified constraints.
Why are these changes needed?
<!-- Please give a short summary of the change and the problem this solves. -->
Topology spread constraints are a Kubernetes feature that helps to distribute pods evenly across nodes to improve high availability and fault tolerance. This test is necessary to ensure that RayCluster configurations support these constraints properly, providing users with greater control over pod scheduling. It helps in scenarios where workload distribution across nodes is critical for resource balancing.

Related issue number
<!-- For example: "Closes #1234" -->
This PR addresses the need for testing topology spread constraints in the KubeRay setup. 

Checks
 I've made sure the tests are passing.
Testing Strategy
 Manual tests: Validated topology spread constraint behavior by observing pod distribution in the test cluster.